### PR TITLE
Fix unpacker error after help text output

### DIFF
--- a/dfu.py
+++ b/dfu.py
@@ -168,6 +168,10 @@ def main():
         # Disconnect from peer device if not done already and clean up.
         ble_dfu.disconnect()
 
+        # If Unpacker for zipfile used then delete Unpacker
+        if unpacker != None:
+           unpacker.delete()
+
     except Exception as e:
         # print traceback.format_exc()
         print("Exception at line {}: {}".format(sys.exc_info()[2].tb_lineno, e))
@@ -175,10 +179,6 @@ def main():
 
     except:
         pass
-
-    # If Unpacker for zipfile used then delete Unpacker
-    if unpacker != None:
-       unpacker.delete()
 
     if options.verbose:
         print("DFU Server done")


### PR DESCRIPTION
Moves the release of unpacker into the main try block where it could have been created (thus eliminating an error in the help text case, where it isn't). Fairly trivial housekeeping item, but the error did momentarily confuse me on the first run.

```
$ ./dfu.py 
[Expected usage output appears here]
Traceback (most recent call last):
  File "./dfu.py", line 196, in <module>
    main()
  File "./dfu.py", line 180, in main
    if unpacker != None:
UnboundLocalError: local variable 'unpacker' referenced before assignment
```